### PR TITLE
Fix chunk index output format

### DIFF
--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -48,7 +48,7 @@ def chunking_doc(text, file_path = None, additional_metadata= None, chunk_size =
     for i,chunk in enumerate(chunks):
         chunk.metadata.update({
             "chunk_id": i, 
-            "chunk_index": f"{(i+1)/len(chunks)}", #chỉ định vị trí index thứ mấy trong tổng chunk, ví dụ như chunk 3/8
+            "chunk_index": f"{i+1}/{len(chunks)}", #chỉ định vị trí index thứ mấy trong tổng chunk, ví dụ như chunk 3/8
             "chunk_size": len(chunk.page_content), #độ dài thực tế của chunk 
             "chunk_start_char": i * max(0,chunk_size - chunk_overlap) #"highlight" đúng đoạn văn bản gốc trên giao diện khi trích dẫn nguồn
         })


### PR DESCRIPTION
Fix: Fix `chunk_index` output to display "index/total chunks" (e.g., "3/8") instead of a decimal division result.

---
<a href="https://cursor.com/background-agent?bcId=bc-709c6810-ea3f-46fa-942e-2a21bd0b8965">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-709c6810-ea3f-46fa-942e-2a21bd0b8965">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

